### PR TITLE
Disabled EnableWriteUnprotector

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -504,7 +504,7 @@
 			<key>EnableSafeModeSlide</key>
 			<true/>
 			<key>EnableWriteUnprotector</key>
-			<true/>
+			<false/>
 			<key>ForceExitBootServices</key>
 			<false/>
 			<key>ProtectMemoryRegions</key>


### PR DESCRIPTION
There's no reason to keep EnableWriteUnprotector enabled if RebuildAppleMemoryMap + SyncRuntimePermissions are enabled ._. 
Please check if it boots and if not, enable DevirtualiseMmio and add an MmioWhitelist entry :")